### PR TITLE
Fix for iOS UI tests

### DIFF
--- a/src/shared/side-menu-content/side-menu-content.component.html
+++ b/src/shared/side-menu-content/side-menu-content.component.html
@@ -3,7 +3,7 @@
 
         <!-- It is a simple option -->
         <ng-template [ngIf]="!option.suboptionsCount">
-            <ion-item class="option" [ngClass]="menuSettings?.showSelectedOption && option.selected ? menuSettings.selectedOptionClass : null" (tap)="select(option)" tappable>
+            <ion-item class="option" [ngClass]="menuSettings?.showSelectedOption && option.selected ? menuSettings.selectedOptionClass : null" (click)="select(option)" tappable>
                 <ion-icon *ngIf="option.iconName" [name]="option.iconName" item-left></ion-icon>
                 {{ option.displayText }} <ion-badge item-right *ngIf="option.badge | async as badgeNo">{{ badgeNo }}</ion-badge>
             </ion-item>


### PR DESCRIPTION
## Motivation

Automated UI test for iOS fails with the side-menu-content component. The reason is that it uses `tap` which requires mouse click to be very short to trigger an action. This PR just changes it for `click`.